### PR TITLE
Fixed a scope bug and changes capture semantics a little

### DIFF
--- a/src/compiler/analysis.rs
+++ b/src/compiler/analysis.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 pub enum ResolvedVar {
     Local(usize),
     Global(usize),
-    // TODO Add upvalues
     Closure(usize),
 }
 
@@ -14,6 +13,7 @@ pub struct AnalysisInfo {
     pub global_count: usize,
     pub resolved_vars: HashMap<usize, ResolvedVar>,
     pub captures: HashMap<usize, Vec<ResolvedVar>>,
+    pub drop_at_scope_end: HashMap<usize, usize>,
 }
 
 impl AnalysisInfo {
@@ -22,6 +22,7 @@ impl AnalysisInfo {
             global_count: 0,
             resolved_vars: HashMap::new(),
             captures: HashMap::new(),
+            drop_at_scope_end: HashMap::new(),
         }
     }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -72,7 +72,10 @@ pub enum Stmt<'src> {
         type_info: Type,
         id: usize,
     },
-    Block(Vec<Stmt<'src>>),
+    Block {
+        body: Vec<Stmt<'src>>,
+        id: usize,
+    },
     If {
         condition: Expr<'src>,
         then_branch: Box<Stmt<'src>>,
@@ -209,9 +212,9 @@ impl Display for Stmt<'_> {
                 type_info,
                 ..
             } => write!(f, "let {}: {} = {}", identifier.lexeme, type_info, value),
-            Stmt::Block(statements) => {
+            Stmt::Block { body, id: _ } => {
                 write!(f, "do\n")?;
-                for statement in statements {
+                for statement in body {
                     write!(f, " {}\n", statement)?;
                 }
                 write!(f, "end")
@@ -280,8 +283,8 @@ impl Stmt<'_> {
         match self {
             Stmt::Expression(expr) => expr.get_line(),
             Stmt::Let { identifier, .. } => identifier.line,
-            Stmt::Block(statements) => {
-                if let Some(first_stmt) = statements.first() {
+            Stmt::Block { body, id: _ } => {
+                if let Some(first_stmt) = body.first() {
                     first_stmt.get_line()
                 } else {
                     0 //might need to add an alternative for empty blocks.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -273,23 +273,25 @@ mod tests {
                     right: number(20.0, 3),
                 }),
             },
-            body: Box::new(Stmt::Block(vec![Stmt::Expression(Expr::Assignment {
-                identifier: Token::new(TokenType::Identifier, 4, "a"),
-                value: Box::new(Expr::Binary {
-                    operator: Token {
-                        token_type: TokenType::Plus,
-                        line: 4,
-                        lexeme: "+",
-                    },
-                    left: var("a", 4, 4),
-                    right: number(1.0, 4),
-                }),
-                id: 5,
-            })])),
+            body: Box::new(Stmt::Block {
+                body: vec![Stmt::Expression(Expr::Assignment {
+                    identifier: Token::new(TokenType::Identifier, 4, "a"),
+                    value: Box::new(Expr::Binary {
+                        operator: Token {
+                            token_type: TokenType::Plus,
+                            line: 4,
+                            lexeme: "+",
+                        },
+                        left: var("a", 4, 4),
+                        right: number(1.0, 4),
+                    }),
+                    id: 5,
+                })],
+                id: 6,
+            }),
         });
         assert_eq!(res, expected);
     }
-
     #[test]
     fn test_parser_error_missing_semicolon() {
         let source = "let a = 10";

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -182,7 +182,10 @@ impl<'src> Parser<'src> {
         }
 
         self.consume(TokT::RightBrace, "Expected '}' after block.")?;
-        Ok(Stmt::Block(statements))
+        Ok(Stmt::Block {
+            body: statements,
+            id: self.get_node_id(),
+        })
     }
     fn if_statement(&mut self) -> Result<Stmt<'src>, ParserError<'src>> {
         let condition = self.expression()?;

--- a/src/typechecker/error.rs
+++ b/src/typechecker/error.rs
@@ -37,6 +37,10 @@ pub enum TypeCheckerError {
     MissingReturnStatement {
         line: usize,
     },
+    AssignmentToCapturedVariable {
+        name: String,
+        line: usize,
+    },
 }
 impl std::fmt::Display for TypeCheckerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -99,6 +103,13 @@ impl std::fmt::Display for TypeCheckerError {
             }
             TypeCheckerError::MissingReturnStatement { line } => {
                 write!(f, "[line {}] Error: Missing return statement.", line)
+            }
+            TypeCheckerError::AssignmentToCapturedVariable { name, line } => {
+                write!(
+                    f,
+                    "[line {}] Error: Cannot assign to captured variable '{}'.",
+                    line, name
+                )
             }
         }
     }

--- a/src/typechecker/expressions.rs
+++ b/src/typechecker/expressions.rs
@@ -1,6 +1,8 @@
+use crate::compiler::analysis::ResolvedVar;
 use crate::parser::ast::{Expr, Literal, Type};
 use crate::token::{Token, TokenType};
 use crate::typechecker::error::TypeCheckerError;
+use crate::typechecker::error::TypeCheckerError::AssignmentToCapturedVariable;
 use crate::typechecker::TypeChecker;
 
 impl<'src> TypeChecker<'src> {
@@ -85,6 +87,12 @@ impl<'src> TypeChecker<'src> {
                             message: "Expected the same type but found something else.",
                         });
                     } else {
+                        if let ResolvedVar::Closure(_) = &resolved {
+                            return Err(AssignmentToCapturedVariable {
+                                name: ctx.name.to_string(),
+                                line: identifier.line,
+                            });
+                        }
                         self.analysis_info.add_var(*id, resolved);
                         value_type
                     }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -49,6 +49,8 @@ pub struct TypeChecker<'src> {
 }
 
 impl<'src> TypeChecker<'src> {
+    // This is used for testing purposes only.
+    #[allow(dead_code)]
     pub fn new() -> Self {
         TypeChecker {
             current_function: FunctionContext::None,

--- a/src/typechecker/return_analysis.rs
+++ b/src/typechecker/return_analysis.rs
@@ -19,8 +19,8 @@ impl<'src> TypeChecker<'src> {
         match stmt {
             Stmt::Expression(_) => Ok(()),
             Stmt::Let { .. } => Ok(()),
-            Stmt::Block(stmts) => {
-                for stmt in stmts {
+            Stmt::Block { body, id: _ } => {
+                for stmt in body {
                     self.check_stmt_returns(stmt)?;
                 }
                 Ok(())
@@ -72,7 +72,7 @@ impl<'src> TypeChecker<'src> {
         match stmt {
             Stmt::Expression(_) => false,
             Stmt::Let { .. } => false,
-            Stmt::Block(stmts) => stmts.iter_mut().any(|e| self.stmt_returns(e)),
+            Stmt::Block { body, id: _id } => body.iter_mut().any(|e| self.stmt_returns(e)),
             Stmt::If {
                 then_branch,
                 else_branch,

--- a/src/typechecker/statements.rs
+++ b/src/typechecker/statements.rs
@@ -64,11 +64,15 @@ impl<'src> TypeChecker<'src> {
 
                 self.analysis_info.add_var(*id, var_ctx);
             }
-            Stmt::Block(statements) => {
+            Stmt::Block { body, id } => {
                 self.begin_scope();
-                for stmt in statements {
+                for stmt in body {
                     self.check_stmt(stmt)?;
                 }
+
+                self.analysis_info
+                    .drop_at_scope_end
+                    .insert(*id, self.variable_scope.last().unwrap().variables.len());
                 self.end_scope();
             }
             Stmt::If {

--- a/src/typechecker/tests.rs
+++ b/src/typechecker/tests.rs
@@ -441,4 +441,30 @@ mod tests {
             .check(ast.as_mut_slice())
             .expect("Should have passed.");
     }
+    #[test]
+    fn test_assignment_to_captured_variable() {
+        let src = r#"{
+            let local = 10;
+            func foo(): number {
+                local = 20;
+                return local;
+            }
+            assert(foo(), 20);
+        }
+        "#;
+
+        let scanner = Scanner::new(src);
+        let mut parser = Parser::new(scanner);
+        let mut ast = parser.parse().expect("Parser failed.");
+        let mut checker = TypeChecker::new();
+        let errors = checker
+            .check(ast.as_mut_slice())
+            .expect_err("Should have failed.");
+        assert_eq!(errors.len(), 1, "Expected 1 error, got {}", errors.len());
+
+        assert!(matches!(
+            errors[0],
+            TypeCheckerError::AssignmentToCapturedVariable { .. }
+        ))
+    }
 }

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -31,7 +31,6 @@ pub enum Opcode {
 
     MakeClosure,
     GetCapture,
-    SetCapture,
 
     Return,
     Halt,

--- a/src/vm/disassembler.rs
+++ b/src/vm/disassembler.rs
@@ -108,10 +108,6 @@ pub fn disassemble_instruction(
             offset += 1;
             println!("GetCapture {}", bytecode[offset]);
         }
-        Opcode::SetCapture => {
-            offset += 1;
-            println!("SetCapture {}", bytecode[offset]);
-        }
     };
     offset + 1
 }


### PR DESCRIPTION
fix(compiler): stack variables weren't popped at the end of a scope.
feat: disallowed capture assignment as it doesn't fit with the languages' semantics.